### PR TITLE
Fix: Resolve vercel.json conflict by merging headers into routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,15 @@
   "routes": [
     {
       "src": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-XSS-Protection", "value": "1; mode=block" }
+      ],
+      "continue": true
+    },
+    {
+      "src": "/(.*)",
       "dest": "/dist/$1"
     },
     {
@@ -27,25 +36,6 @@
     {
       "src": "/(.*)",
       "dest": "/index.html"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        }
-      ]
     }
   ]
 } 


### PR DESCRIPTION
The vercel.json configuration had a conflict because both `routes` and a top-level `headers` key were present. This is disallowed by Vercel's configuration rules.

This commit resolves the issue by:
1. Moving the global headers previously defined in the top-level `headers` key into a new route at the beginning of the `routes` array. This new route applies to all paths (`src: "/(.*)"`) and uses `"continue": true` to ensure other routes are still processed.
2. Removing the conflicting top-level `headers` key.

This change ensures the `vercel.json` file is valid according to Vercel's specifications while preserving the intended header configurations.