### PR TITLE
Fix: Correct routes[0].headers format in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,11 +12,11 @@
   "routes": [
     {
       "src": "/(.*)",
-      "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "X-XSS-Protection", "value": "1; mode=block" }
-      ],
+      "headers": {
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block"
+      },
       "continue": true
     },
     {


### PR DESCRIPTION
The `routes[0].headers` field was previously an array of objects, which caused an 'Invalid request: `routes[0].headers` should be object' error.

This commit changes the `headers` field to be a single object, mapping header keys to their respective values, aligning with the expected format and resolving the issue.